### PR TITLE
Create Stargarden terminal adventure

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org/>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# fun-project
+# Stargarden
+
+Stargarden is a pocket-sized narrative adventure that lives in your terminal. Each
+in-game day, a new cosmic event challenges your crew. Balance hull integrity,
+crew morale, and fuel reserves as you chart a course toward the mythical Aurora
+Rendezvous station.
+
+## Features
+
+- **Choice-driven storytelling** – respond to colorful sci-fi events with unique
+  outcomes that shape your ship and crew.
+- **Dynamic status tracking** – hull, morale, and fuel respond immediately to
+your decisions, keeping each run tense and replayable.
+- **Collectible curiosities** – gather strange cargo like Nebula Blooms and
+  Singing Meteor Shards to bring back to the rendezvous.
+
+## Getting Started
+
+This project targets Python 3.10 or newer.
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+You can run the adventure directly with:
+
+```bash
+python main.py
+```
+
+Alternatively, import the package and start the game manually:
+
+```python
+from stargarden import run_game
+
+run_game()
+```
+
+## Running Tests
+
+The project includes lightweight unit tests for core mechanics. Execute them
+with:
+
+```bash
+python -m pytest
+```
+
+## License
+
+This project is released into the public domain under the [Unlicense](LICENSE).

--- a/main.py
+++ b/main.py
@@ -1,0 +1,7 @@
+"""Entry point for playing Stargarden."""
+
+from stargarden import run_game
+
+
+if __name__ == "__main__":
+    run_game()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "stargarden"
+version = "0.1.0"
+description = "A pocket-sized narrative space adventure for the terminal."
+authors = [{name = "Fun Project"}]
+readme = "README.md"
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: Public Domain",
+    "Intended Audience :: End Users/Desktop",
+    "Topic :: Games/Entertainment :: Role-Playing",
+]
+
+[project.scripts]
+stargarden = "stargarden.game:run_game"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[options]
+package_dir =
+    =src
+packages = find:
+
+[options.packages.find]
+where = src

--- a/src/stargarden/__init__.py
+++ b/src/stargarden/__init__.py
@@ -1,0 +1,5 @@
+"""Stargarden: a tiny narrative space adventure."""
+
+from .game import run_game
+
+__all__ = ["run_game"]

--- a/src/stargarden/events.py
+++ b/src/stargarden/events.py
@@ -1,0 +1,221 @@
+"""Narrative events for the Stargarden adventure."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Callable, List
+
+from .state import Player
+
+
+OutcomeGenerator = Callable[[Player, random.Random], str]
+
+
+@dataclass
+class Choice:
+    label: str
+    resolve: OutcomeGenerator
+
+
+@dataclass
+class Event:
+    name: str
+    intro: str
+    choices: List[Choice]
+
+
+def make_events() -> List[Event]:
+    """Create the reusable list of events."""
+
+    return [
+        _nebula_drift(),
+        _stowaway_automaton(),
+        _luminous_garden(),
+        _quantum_markets(),
+        _singing_meteor(),
+        _wayward_signal(),
+    ]
+
+
+def _nebula_drift() -> Event:
+    def manual(player: Player, rng: random.Random) -> str:
+        player.adjust(fuel=-1)
+        if rng.random() < 0.4:
+            player.adjust(hull=-2)
+            return (
+                "The ship rattles as unseen rocks graze the hull. "
+                "You steady the wheel and promise to recalibrate the sensors."
+            )
+        player.adjust(morale=1)
+        return "Your daring navigation thrills the crew, and the nebula thins behind you."
+
+    def drift(player: Player, rng: random.Random) -> str:
+        player.adjust(morale=-1)
+        player.adjust(fuel=1)
+        if rng.random() < 0.5:
+            player.add_cargo(["Nebula Bloom"])
+            return (
+                "You let the ship drift, gathering luminous spores that glow in the cargo bay."
+            )
+        return "Patience pays off as currents push you clear without further incident."
+
+    return Event(
+        name="Nebula Drift",
+        intro=(
+            "A rose-colored nebula envelopes the Stargarden. Turbulence jostles the hull and "
+            "the guidance systems flicker."
+        ),
+        choices=[
+            Choice("Navigate manually through the haze.", manual),
+            Choice("Cut engines and drift with the currents.", drift),
+        ],
+    )
+
+
+def _stowaway_automaton() -> Event:
+    def recruit(player: Player, rng: random.Random) -> str:
+        player.adjust(morale=2)
+        if "Patchwork Automaton" not in player.cargo:
+            player.add_cargo(["Patchwork Automaton"])
+        return (
+            "The automaton whirs happily, integrating with the crew and fixing dangling wires."
+        )
+
+    def trade(player: Player, rng: random.Random) -> str:
+        player.adjust(fuel=2)
+        player.adjust(morale=-1)
+        return (
+            "You broker a deal, trading the automaton to a merchant convoy for fuel cells."
+        )
+
+    return Event(
+        name="Stowaway Automaton",
+        intro=(
+            "A tiny automaton rolls out from behind the hydroponics bay. Its eye-lights blink "
+            "with hopeful rhythm."
+        ),
+        choices=[
+            Choice("Offer the automaton a place on the crew.", recruit),
+            Choice("Trade the automaton to the next convoy.", trade),
+        ],
+    )
+
+
+def _luminous_garden() -> Event:
+    def explore(player: Player, rng: random.Random) -> str:
+        player.adjust(morale=2)
+        if rng.random() < 0.3:
+            player.adjust(hull=-1)
+            return (
+                "Bioluminescent vines curl around the ship, leaving scratches but filling the "
+                "mess hall with gentle light."
+            )
+        player.add_cargo(["Starseed"])
+        return "The crew returns with pockets full of starseeds that hum softly."
+
+    def study(player: Player, rng: random.Random) -> str:
+        player.adjust(fuel=1)
+        player.adjust(morale=1)
+        player.add_cargo(["Garden Samples"])
+        return (
+            "Scans reveal the garden's energy signatures. The data keeps the engines efficient "
+            "for days."
+        )
+
+    return Event(
+        name="Luminous Garden",
+        intro=(
+            "A rogue asteroid carries a thriving bioluminescent garden, beckoning with soft "
+            "greens and blues."
+        ),
+        choices=[
+            Choice("Send an away team to explore the garden.", explore),
+            Choice("Study the garden from orbit and collect samples.", study),
+        ],
+    )
+
+
+def _quantum_markets() -> Event:
+    def barter(player: Player, rng: random.Random) -> str:
+        if player.cargo:
+            sold_item = rng.choice(player.cargo)
+            player.remove_cargo([sold_item])
+            player.adjust(fuel=2, morale=1)
+            return f"You trade {sold_item} for a cache of fuel and energizing stories."
+        player.adjust(fuel=1)
+        return "Without anything to trade, a vendor slips you a sympathy ration of fuel."
+
+    def perform(player: Player, rng: random.Random) -> str:
+        player.adjust(morale=2)
+        if rng.random() < 0.4:
+            player.adjust(fuel=-1)
+            return "The performance dazzles the crowd, but the celebration burns extra fuel."
+        return "Your impromptu concert lifts spirits across the market promenade."
+
+    return Event(
+        name="Quantum Markets",
+        intro=(
+            "You dock with a wandering marketplace that flickers in and out of phase with "
+            "reality."
+        ),
+        choices=[
+            Choice("Barter with curious merchants.", barter),
+            Choice("Perform a zero-gravity concert for tips.", perform),
+        ],
+    )
+
+
+def _singing_meteor() -> Event:
+    def chase(player: Player, rng: random.Random) -> str:
+        player.adjust(fuel=-2)
+        if rng.random() < 0.5:
+            player.add_cargo(["Singing Meteor Shard"])
+            player.adjust(morale=2)
+            return "You capture a shard that harmonizes with the ship's engines."
+        player.adjust(hull=-1)
+        return "The meteor slips away, leaving only scorch marks to polish."
+
+    def listen(player: Player, rng: random.Random) -> str:
+        player.adjust(morale=1)
+        return "The haunting melody guides your charts, revealing a shortcut through safe lanes."
+
+    return Event(
+        name="Singing Meteor",
+        intro=(
+            "Sensors detect a meteor trailing a trail of harmonics that resonate in the crew's "
+            "bones."
+        ),
+        choices=[
+            Choice("Chase the meteor and attempt capture.", chase),
+            Choice("Record the melody and adjust your course.", listen),
+        ],
+    )
+
+
+def _wayward_signal() -> Event:
+    def decode(player: Player, rng: random.Random) -> str:
+        player.adjust(morale=-1)
+        player.adjust(fuel=1)
+        return (
+            "You spend the night decoding the signal—an ancient map that points toward the "
+            "Aurora Rendezvous."
+        )
+
+    def reply(player: Player, rng: random.Random) -> str:
+        player.adjust(morale=2)
+        if rng.random() < 0.3:
+            player.adjust(fuel=-2)
+            return "The reply summons lost explorers who celebrate with you, but their tugs drain fuel."
+        return "Your response echoes across the stars, and hopeful voices answer back."
+
+    return Event(
+        name="Wayward Signal",
+        intro=(
+            "A signal pings the comms array, repeating coordinates wrapped in forgotten dialects."
+        ),
+        choices=[
+            Choice("Decode the signal into a proper star map.", decode),
+            Choice("Reply and invite whoever sent it to meet you.", reply),
+        ],
+    )

--- a/src/stargarden/game.py
+++ b/src/stargarden/game.py
@@ -1,0 +1,68 @@
+"""Interactive game loop for Stargarden."""
+
+from __future__ import annotations
+
+import random
+
+from .events import Event, make_events
+from .render import banner, finale_message, status_block
+from .state import Player
+
+
+def run_game(*, seed: int | None = None) -> None:
+    """Launch the Stargarden adventure in the console."""
+
+    rng = random.Random(seed)
+    events = make_events()
+
+    print(banner())
+    print("\nWelcome to Stargarden, a pocket-sized spacefaring tale!\n")
+
+    name = input("Captain, what is your name? ").strip() or "Nova"
+    player = Player(name=name)
+
+    print(
+        "\nYour mission: guide the Stargarden to the Aurora Rendezvous before the seventh sunrise."
+    )
+
+    while not player.is_stranded() and player.day <= 7:
+        print("\n" + "═" * 72)
+        print(f"Day {player.day}: {player.name}, the crew awaits your decision.")
+
+        event = rng.choice(events)
+        _present_event(event, rng, player)
+
+        if player.is_stranded():
+            break
+
+        player.advance_day()
+
+    print(finale_message(player))
+
+
+def _present_event(event: Event, rng: random.Random, player: Player) -> None:
+    print(f"\n{event.name}\n{'-' * len(event.name)}")
+    print(event.intro)
+
+    print("\nChoices:")
+    for index, choice in enumerate(event.choices, start=1):
+        print(f"  {index}. {choice.label}")
+
+    selection = _prompt_choice(len(event.choices))
+    choice = event.choices[selection - 1]
+
+    outcome = choice.resolve(player, rng)
+    print(f"\n{outcome}\n")
+    print(status_block(player))
+
+
+def _prompt_choice(number_of_choices: int) -> int:
+    while True:
+        raw = input("\nYour decision (enter the number): ").strip()
+        if not raw.isdigit():
+            print("Please enter the number of the choice you wish to make.")
+            continue
+        value = int(raw)
+        if 1 <= value <= number_of_choices:
+            return value
+        print(f"Choose a number between 1 and {number_of_choices}.")

--- a/src/stargarden/render.py
+++ b/src/stargarden/render.py
@@ -1,0 +1,51 @@
+"""Rendering helpers for the Stargarden adventure."""
+
+from __future__ import annotations
+
+from .state import Player
+
+
+def banner() -> str:
+    return r"""
+   _____ _                     _                       _
+  / ____| |                   | |                     | |
+ | (___ | |_ _ __ __ _  __ _  | |     ___   __ _  __ _| |_ ___  _ __
+  \___ \| __| '__/ _` |/ _` | | |    / _ \ / _` |/ _` | __/ _ \| '__|
+  ____) | |_| | | (_| | (_| | | |___| (_) | (_| | (_| | || (_) | |
+ |_____/ \__|_|  \__,_|\__, | |______\___/ \__, |\__,_|\__\___/|_|
+                        __/ |              __/ |
+                       |___/              |___/
+""".strip("\n")
+
+
+def status_block(player: Player) -> str:
+    return "\n".join(
+        [
+            _stat_line("Hull", player.hull, "🛠"),
+            _stat_line("Morale", player.morale, "✨"),
+            _stat_line("Fuel", player.fuel, "⛽"),
+            f"Cargo: {', '.join(player.cargo) if player.cargo else '(empty)'}",
+        ]
+    )
+
+
+def finale_message(player: Player) -> str:
+    if player.is_stranded():
+        return (
+            "\nYour journey ends before the Aurora Rendezvous. "
+            f"{player.failure_reason()}\n"
+        )
+
+    days = player.day - 1
+    cargo = ", ".join(player.cargo) if player.cargo else "memories of the stars"
+    return (
+        "\nThe Aurora Rendezvous station shimmers ahead!\n"
+        f"In {days} days you carried {cargo} across the cosmos.\n"
+        "The crew of the Stargarden cheers your command.\n"
+    )
+
+
+def _stat_line(label: str, value: int, icon: str) -> str:
+    filled = "█" * value
+    empty = "·" * max(0, 12 - value)
+    return f"{icon} {label:<6}: {filled}{empty} ({value})"

--- a/src/stargarden/state.py
+++ b/src/stargarden/state.py
@@ -1,0 +1,61 @@
+"""Game state data structures for Stargarden."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List
+
+
+@dataclass
+class Player:
+    """Represents the captain and their ship."""
+
+    name: str
+    hull: int = 10
+    morale: int = 10
+    fuel: int = 10
+    cargo: List[str] = field(default_factory=list)
+    day: int = 1
+
+    max_stat: int = 12
+
+    def adjust(self, *, hull: int = 0, morale: int = 0, fuel: int = 0) -> None:
+        """Apply stat changes while clamping to sensible limits."""
+
+        self.hull = self._clamp(self.hull + hull)
+        self.morale = self._clamp(self.morale + morale)
+        self.fuel = self._clamp(self.fuel + fuel)
+
+    def add_cargo(self, items: Iterable[str]) -> None:
+        for item in items:
+            if item not in self.cargo:
+                self.cargo.append(item)
+
+    def remove_cargo(self, items: Iterable[str]) -> None:
+        to_remove = set(items)
+        self.cargo = [item for item in self.cargo if item not in to_remove]
+
+    def advance_day(self) -> None:
+        self.day += 1
+
+    def is_stranded(self) -> bool:
+        return self.hull <= 0 or self.morale <= 0 or self.fuel <= 0
+
+    def failure_reason(self) -> str:
+        if self.hull <= 0:
+            return "Your hull gave out under cosmic pressure."
+        if self.morale <= 0:
+            return "The crew's spirit faded into the nebula."
+        if self.fuel <= 0:
+            return "You drift endlessly with empty tanks."
+        return "You vanished into deep space."  # fallback
+
+    def status_summary(self) -> str:
+        cargo_text = ", ".join(self.cargo) if self.cargo else "(empty)"
+        return (
+            f"Hull: {self.hull} | Morale: {self.morale} | Fuel: {self.fuel} | "
+            f"Cargo: {cargo_text}"
+        )
+
+    def _clamp(self, value: int) -> int:
+        return max(0, min(self.max_stat, value))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Test configuration for Stargarden."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,41 @@
+"""Unit tests for Stargarden events and state."""
+
+from __future__ import annotations
+
+import random
+
+from stargarden.events import make_events
+from stargarden.state import Player
+
+
+def test_events_have_choices():
+    events = make_events()
+    assert events, "Expected at least one event"
+    for event in events:
+        assert len(event.choices) >= 2
+        for choice in event.choices:
+            assert callable(choice.resolve)
+
+
+def test_player_adjust_clamps_values():
+    player = Player(name="Test")
+    player.adjust(hull=5, morale=5, fuel=5)
+    assert player.hull == player.max_stat
+    assert player.morale == player.max_stat
+    assert player.fuel == player.max_stat
+
+    player.adjust(hull=-50, morale=-50, fuel=-50)
+    assert player.hull == 0
+    assert player.morale == 0
+    assert player.fuel == 0
+
+
+def test_choice_resolution_changes_state():
+    player = Player(name="Tester")
+    events = make_events()
+    event = events[0]
+    initial = (player.hull, player.morale, player.fuel)
+    message = event.choices[0].resolve(player, random.Random(42))
+    assert isinstance(message, str)
+    final = (player.hull, player.morale, player.fuel)
+    assert final != initial


### PR DESCRIPTION
## Summary
- create Stargarden, a narrative terminal adventure with branching events and status tracking
- add packaging metadata, project documentation, and Unlicense text
- include automated tests covering player stats and event definitions

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_b_68e420783ccc832795361f323ac56dcb